### PR TITLE
Meta information item show

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :meta_title, "#{@item.name} is on #{DEFAULT_META["meta_product_name"]}" %>
+<% content_for :meta_description, @item.description %>
+<% content_for :meta_image, cl_image_path(@item.photo.path) %>
+
 <div class="container">
 <div class="card card-item-show justify-content-center">
   <div class="card-header text-center text-capitalize"><%= @item.name %></div>


### PR DESCRIPTION
Added meta information on top of the page. No changes to the rest of the code

<% content_for :meta_title, "#{@item.name} is on #{DEFAULT_META["meta_product_name"]}" %>
<% content_for :meta_description, @item.description %>
<% content_for :meta_image, cl_image_path(@item.photo.path) %>